### PR TITLE
Decode command output when binary string is returned

### DIFF
--- a/better_setuptools_git_version.py
+++ b/better_setuptools_git_version.py
@@ -13,6 +13,9 @@ def _get_command_output(command):
     except subprocess.CalledProcessError as e:
         output = e.output
 
+    if type(output) is bytes:
+        output = output.decode()
+
     return output.strip()
 
 


### PR DESCRIPTION
I think this should fix errors like the following where a binary string in the version is causing issues.  Can you check it out?

```
~/Projects/greatfet/libgreat/host $ python setup.py build
fatal: ambiguous argument 'bv2019.9.1': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
/Users/chris/.anyenv/envs/pyenv/versions/greatfet/lib/python3.8/site-packages/setuptools/dist.py:479: UserWarning: The version specified ("b'v2019.9.1'.dev+git.b'67258250'") is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  warnings.warn(
running build
running build_py
running egg_info
writing pygreat.egg-info/PKG-INFO
writing dependency_links to pygreat.egg-info/dependency_links.txt
writing entry points to pygreat.egg-info/entry_points.txt
writing requirements to pygreat.egg-info/requires.txt
writing top-level names to pygreat.egg-info/top_level.txt
reading manifest file 'pygreat.egg-info/SOURCES.txt'
writing manifest file 'pygreat.egg-info/SOURCES.txt'
```