### PR TITLE
Prefer collections.abc.Mapping if present

### DIFF
--- a/better_setuptools_git_version.py
+++ b/better_setuptools_git_version.py
@@ -80,7 +80,9 @@ def get_version(template="{tag}.dev{sha}", starting_version="0.1.0"):
 
 def validate_version_config(dist, _, config):
     """Validate the `version_config` keyword in a client setup.py script."""
-    if not isinstance(config, collections.Mapping):
+    # collections.Mapping and friends moved into collections.abc in python 3.10
+    collections_compat = getattr(collections, 'abc', collections)
+    if not isinstance(config, collections_compat.Mapping):
         raise TypeError("Config should be a dictionary with `version_format` and `starting_version` keys.")
 
     if "starting_version" not in config:


### PR DESCRIPTION
Abstract base classes being direct children of the collections module
was deprecated in python 3.9 [1] and compatibility was removed in 3.10
[2]. They have been moved to collections.abc.

The cheapest way for us to work around this is while maintaining
compatibility with python versions lower than 3.10 is to use
`collections.abc` if it's present, otherwise shrug and try to use
`collections` instead.

I've tested against python versions 3.10.1 and 3.8.5 by using this
module to build libgreat.

[1]: https://docs.python.org/3/whatsnew/3.9.html#you-should-check-for-deprecationwarning-in-your-code
[2]: https://docs.python.org/3/whatsnew/3.10.html#removed